### PR TITLE
add build context to docker-compose.yml

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -7,7 +7,9 @@ services:
             - POSTGRES_PASSWORD=taskflow
             - POSTGRES_DB=taskflow
     scheduler:
-        build: Dockerfile.scheduler
+        build:
+          context: ./
+          dockerfile: Dockerfile.scheduler
         restart: always
         depends_on:
             - postgres


### PR DESCRIPTION
Currently, `docker-compose up` fails because it can't build `Dockerfile.scheduler`:

```
TypeError: You must specify a directory to build in path
Failed to execute script docker-compose
```
According to the [build docs](https://docs.docker.com/compose/compose-file/#build), it looks like if you want to specify an alternate filename for the Dockerfile, you need to specify the context. Oddly, `build: ./Dockerfile.scheduler` isn't enough.